### PR TITLE
Add dirY to navMove calls to allow horizontal traverse

### DIFF
--- a/navigationMixin.jsx
+++ b/navigationMixin.jsx
@@ -37,7 +37,7 @@ module.exports = {
             } else if (typeof this.navOut === 'function') {
                 return this.navOut(dir, dirY);
             } else if (this.navData.parent) {
-                return this.navData.parent.navGetMove(dir);
+                return this.navData.parent.navGetMove(dir, dirY);
             }
         }.bind(this);
 


### PR DESCRIPTION
I found problems having a side menu on the left and a grid, when on the leftmost item on the grid pressing left should focus the menu, it seems like the dirY parameter was not being propagated.

This made it work.
